### PR TITLE
NAV-font på "org. nr. [...]"

### DIFF
--- a/src/bedriftsmeny/Virksomhetsvelger/Menyknapp/Menyknapp.tsx
+++ b/src/bedriftsmeny/Virksomhetsvelger/Menyknapp/Menyknapp.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Undertittel, Element } from 'nav-frontend-typografi';
+import { Undertittel, Element, Normaltekst } from 'nav-frontend-typografi';
 import { NedChevron, OppChevron } from 'nav-frontend-chevron';
 import UnderenhetIkon from '../Menyvalg/Underenhetsvelger/Organisasjonsbeskrivelse/UnderenhetIkon';
 import './Menyknapp.less';
@@ -42,7 +42,7 @@ const MenyKnapp = ({ navn, orgnummer, brukOverskrift, erApen, setErApen, setSoke
                 <UnderenhetIkon classname="menyknapp-ikon" />
                 <div className="menyknapp-beskrivelse">
                     <Navn className="menyknapp-navn">{navn}</Navn>
-                    org. nr. {orgnummer}
+                    <Normaltekst>org. nr. {orgnummer}</Normaltekst>
                 </div>
                 {oppChevron ? (
                     <OppChevron className="menyknapp-chevron" />


### PR DESCRIPTION
Manglet NAV-font der det står f. eks. "org. nr. 811076422". Den var ustylet.

Før denne PR-en:
![Screenshot 2020-09-24 at 09 10 11](https://user-images.githubusercontent.com/1241637/94112728-24fdcc80-fe46-11ea-8393-c5009dada5e7.png)

Etter:
![Screenshot 2020-09-24 at 09 11 59](https://user-images.githubusercontent.com/1241637/94112768-321abb80-fe46-11ea-80b6-a074d1871349.png)
