### PR TITLE
Endrer tsconfig slik at den også genererer esm filer av pakken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.4.4-rc1",
+    "version": "6.5.0-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.4.4-rc1",
+            "version": "6.5.0-rc1",
             "license": "MIT",
             "dependencies": {
                 "@types/amplitude-js": "^8.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.5.0",
+    "version": "6.5.0-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.5.0",
+            "version": "6.5.0-rc1",
             "license": "MIT",
             "dependencies": {
                 "@types/amplitude-js": "^8.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.4.3",
+    "version": "6.4.4-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.4.3",
+            "version": "6.4.4-rc1",
             "license": "MIT",
             "dependencies": {
                 "@types/amplitude-js": "^8.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.5.0-rc1",
+    "version": "6.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.5.0-rc1",
+            "version": "6.5.0",
             "license": "MIT",
             "dependencies": {
                 "@types/amplitude-js": "^8.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.5.0-rc1",
+    "version": "6.5.0",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
         "url": "git+https://github.com/navikt/bedriftsmeny.git"
     },
     "source": "src/index.html",
-    "main": "lib/Bedriftsmeny.js",
-    "types": "lib/Bedriftsmeny.d.ts",
+    "main": "lib/cjs/Bedriftsmeny.js",
+    "module": "lib/esm/Bedriftsmeny.js",
+    "types": "lib/types/Bedriftsmeny.d.ts",
     "files": [
         "lib",
         "src/bedriftsmeny"
@@ -22,7 +23,7 @@
         "clean": "rm -rf lib",
         "prebuild": "npm run clean",
         "build": "run-p build:ts build:css",
-        "build:ts": "tsc --project tsconfig.build.json",
+        "build:ts": "tsc -b ./tsconfig.build.cjs.json ./tsconfig.build.esm.json ./tsconfig.build.types.json",
         "build:css": "postcss --use postcss-import -o lib/bedriftsmeny.css src/bedriftsmeny/index.css"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.4.3",
+    "version": "6.4.4-rc1",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.5.0",
+    "version": "6.5.0-rc1",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.4.4-rc1",
+    "version": "6.5.0-rc1",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/src/bedriftsmeny/Bedriftsmeny.tsx
+++ b/src/bedriftsmeny/Bedriftsmeny.tsx
@@ -90,6 +90,7 @@ export {ForebyggeSykefravaer} from "./piktogrammer/ForebyggeSykefravaer";
 export {Kandidater} from "./piktogrammer/Kandidater";
 export {Refusjon} from "./piktogrammer/Refusjon";
 export {MSAIkon} from "./piktogrammer/MSAIkon";
+export {hentAlleJuridiskeEnheter} from "./hentAlleJuridiskeEnheter"
 
 export type BedriftsmenyHeaderProps = {
     tittel?: string;

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./lib/cjs",
+        "module": "commonjs"
+    }
+}

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./lib/esm",
+        "module": "esnext"
+    }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,6 @@
         "outDir": "lib",
         "target": "esnext",
         "lib": ["dom", "esnext"],
-        "declaration": true,
         "moduleResolution": "node",
         "sourceMap": true,
         "strict": true,

--- a/tsconfig.build.types.json
+++ b/tsconfig.build.types.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./lib/types",
+        "declaration": true,
+        "emitDeclarationOnly": true
+    }
+}


### PR DESCRIPTION
Flytter også type-deklarasjonenen til lib/types da denne er delt mellom esm og cjs.

Bakgrunnen for denne PRen er at webpack o.l. er langt bedre til å eliminere død kode i esm moduler enn i cjs. Ved å importere esm versjonen av bedriftsvelgeren reduserte vi den ukomprimerte størrelsen på bundle med ~920KB. (hvor 525KB er hele ds-icons pakken).

før:
<img width="1856" alt="Screenshot 2023-04-28 at 14 40 43" src="https://user-images.githubusercontent.com/32471637/235150303-8bcb39b5-6335-41c6-98d2-cf1a57b9b719.png">

etter:
<img width="1856" alt="Screenshot 2023-04-28 at 14 40 56" src="https://user-images.githubusercontent.com/32471637/235150427-17262063-f054-4333-8264-6365f39865e0.png">
