### PR TITLE
Tag 2216 uu fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export default function() {
 
 ```sh
 npm install
-npm start
+npm run dev
 ```
 
 ## Publisering på NPM
@@ -113,16 +113,6 @@ commit med det nye versjonsnummeret som commit message.
 Det opprettes samtidig en ny tag med det nye versjonsnummeret.
 
 Commits til master med ny versjon i `package.json` vil publiseres til NPM.
-
-## Stack
-
-### Bundling
-
-Bedriftsmenyen bygges med Webpack og Babel. Babel klarer å tolke TypeScript med `@babel/preset-typescript` og JSX med `@babel/preset-react` (se _babel.config.js_). Less kompileres til CSS og bundles sammen med JavaScript i _lib/bedriftsmeny.css_. Babel klarer ikke å generere deklarasjonsfiler for TypeScript, så vi gjør dette i et eget steg som en del av bygget.
-
-### Utvikling
-
-Under utvikling (`npm start`) bygges appen med Parcel og en egen TypeScript-konfigurasjonsfil.
 
 ## Kontakt oss
 Opprett issue i repository hvis du lurer på noe.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.12.3",
+    "version": "6.13.0-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.12.3",
+            "version": "6.13.0-rc1",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc2",
+    "version": "6.13.0-rc3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.13.0-rc2",
+            "version": "6.13.0-rc3",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc3",
+    "version": "6.13.0-rc4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.13.0-rc3",
+            "version": "6.13.0-rc4",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc4",
+    "version": "6.13.0-rc5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.13.0-rc4",
+            "version": "6.13.0-rc5",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",
@@ -30,7 +30,7 @@
                 "postcss-import": "^15.1.0",
                 "prettier": "2.2.1",
                 "process": "^0.11.10",
-                "typescript": "^4.1.3"
+                "typescript": "^5.3.3"
             },
             "peerDependencies": {
                 "@navikt/ds-css": ">=2",
@@ -2721,16 +2721,16 @@
             "dev": true
         },
         "node_modules/typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/unbox-primitive": {
@@ -4773,9 +4773,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc6",
+    "version": "6.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.13.0-rc6",
+            "version": "6.13.0",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc5",
+    "version": "6.13.0-rc6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.13.0-rc5",
+            "version": "6.13.0-rc6",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc1",
+    "version": "6.13.0-rc2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/bedriftsmeny",
-            "version": "6.13.0-rc1",
+            "version": "6.13.0-rc2",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc6",
+    "version": "6.13.0",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc2",
+    "version": "6.13.0-rc3",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc4",
+    "version": "6.13.0-rc5",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",
@@ -56,7 +56,7 @@
         "postcss-import": "^15.1.0",
         "prettier": "2.2.1",
         "process": "^0.11.10",
-        "typescript": "^4.1.3"
+        "typescript": "^5.3.3"
     },
     "dependencies": {
         "fuzzysort": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.12.3",
+    "version": "6.13.0-rc1",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc1",
+    "version": "6.13.0-rc2",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc3",
+    "version": "6.13.0-rc4",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/bedriftsmeny",
-    "version": "6.13.0-rc5",
+    "version": "6.13.0-rc6",
     "description": "Bedriftsvelger og -meny for innlogget arbeidsgiver. Laget av TAG (Tjenester for Arbeidsgivere).",
     "author": "NAVIKT",
     "license": "MIT",

--- a/src/bedriftsmeny/velger/Dropdown.tsx
+++ b/src/bedriftsmeny/velger/Dropdown.tsx
@@ -9,7 +9,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 
 const Dropdown = ({erApen, ariaLabel, friKomponent,  children, ...divProperties}: Props) => {
   return erApen ? <div
-    role='dialog'
+    role='menu'
     aria-label={ariaLabel}
     className={`Dropdown-panel ${!friKomponent ? "Dropdown-panel-Bedriftsmeny" : ""}`}
     {...divProperties}

--- a/src/bedriftsmeny/velger/Dropdown.tsx
+++ b/src/bedriftsmeny/velger/Dropdown.tsx
@@ -9,7 +9,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 
 const Dropdown = ({erApen, ariaLabel, friKomponent,  children, ...divProperties}: Props) => {
   return erApen ? <div
-    role='menu'
+    role='dialog'
     aria-label={ariaLabel}
     className={`Dropdown-panel ${!friKomponent ? "Dropdown-panel-Bedriftsmeny" : ""}`}
     {...divProperties}

--- a/src/bedriftsmeny/velger/JuridiskEnhet.css
+++ b/src/bedriftsmeny/velger/JuridiskEnhet.css
@@ -70,6 +70,10 @@
     width: 100%;
     padding: var(--a-spacing-3) var(--a-spacing-4);
 }
+.navbm-virksomhetsvelger__underenhet-innhold:focus {
+    /* liten hack da programmatisk focus ikke funker på ds-react lenger. usikker på hvorfor */
+    box-shadow: inset 0 0 0 2px var(--ac-button-tertiary-focus-border, var(--a-border-action)), var(--a-shadow-focus);
+}
 .navbm-virksomhetsvelger__underenhet-innhold > span {
     width: 100%;
 }

--- a/src/bedriftsmeny/velger/JuridiskEnhet.tsx
+++ b/src/bedriftsmeny/velger/JuridiskEnhet.tsx
@@ -2,7 +2,7 @@ import React, {ForwardedRef, forwardRef, useState} from 'react';
 import {Office1, Success} from '@navikt/ds-icons';
 import {Accordion, BodyShort, Button} from '@navikt/ds-react';
 import {JuridiskEnhetMedUnderEnheterArray, Organisasjon} from '../organisasjon';
-import {a11yOrgnr} from "@/bedriftsmeny/velger/utils";
+import {a11yOrgnr} from "./utils";
 
 type Props = {
     juridiskEnhet: JuridiskEnhetMedUnderEnheterArray;

--- a/src/bedriftsmeny/velger/JuridiskEnhet.tsx
+++ b/src/bedriftsmeny/velger/JuridiskEnhet.tsx
@@ -96,8 +96,7 @@ const Underenhet = forwardRef<HTMLButtonElement, UnderenhetProps>(({valgt, onCli
         <div className='navbm-virksomhetsvelger__enhet'>
             <Office1 aria-hidden={true}/>
             <div className='navbm-virksomhetsvelger__enhet-tekst'>
-                <BodyShort className='navbm-virksomhetsvelger__enhet-tittel'
-                           aria-label={`Underenhet ${underenhet.Name}`}>
+                <BodyShort className='navbm-virksomhetsvelger__enhet-tittel'>
                     {underenhet.Name}
                 </BodyShort>
                 <BodyShort aria-label={`virksomhetsnummer ${a11yOrgnr(underenhet.OrganizationNumber)}`}>
@@ -125,7 +124,7 @@ type HovedenhetProps = {
 const Hovedenhet = ({hovedenhet, valgt, antallUnderenheter}: HovedenhetProps) =>
     <div className='navbm-virksomhetsvelger__enhet navbm-virksomhetsvelger__enhet--juridisk'>
         <div className='navbm-virksomhetsvelger__enhet-tekst'>
-            <BodyShort className='navbm-virksomhetsvelger__enhet-tittel' aria-label={`Hovedenhet ${hovedenhet.Name}`}>
+            <BodyShort className='navbm-virksomhetsvelger__enhet-tittel'>
                 {hovedenhet.Name}
             </BodyShort>
             <BodyShort>

--- a/src/bedriftsmeny/velger/JuridiskEnhet.tsx
+++ b/src/bedriftsmeny/velger/JuridiskEnhet.tsx
@@ -83,7 +83,6 @@ const Underenhet = forwardRef<HTMLButtonElement, UnderenhetProps>(({valgt, onCli
     <Button
         ref={ref}
         tabIndex={valgt ? 0 : -1}
-        role='menuitemradio'
         aria-checked={valgt}
         variant='tertiary'
         onClick={() => onClick(underenhet)}

--- a/src/bedriftsmeny/velger/JuridiskEnhet.tsx
+++ b/src/bedriftsmeny/velger/JuridiskEnhet.tsx
@@ -83,7 +83,7 @@ const Underenhet = forwardRef<HTMLButtonElement, UnderenhetProps>(({valgt, onCli
     <Button
         ref={ref}
         tabIndex={valgt ? 0 : -1}
-        aria-checked={valgt}
+        aria-pressed={valgt}
         variant='tertiary'
         onClick={() => onClick(underenhet)}
         className='navbm-virksomhetsvelger__underenhet-innhold'

--- a/src/bedriftsmeny/velger/JuridiskEnhet.tsx
+++ b/src/bedriftsmeny/velger/JuridiskEnhet.tsx
@@ -81,6 +81,7 @@ type UnderenhetProps = {
 
 const Underenhet = forwardRef<HTMLButtonElement, UnderenhetProps>(({valgt, onClick, underenhet}, ref) =>
     <Button
+        type="button"
         ref={ref}
         tabIndex={valgt ? 0 : -1}
         aria-pressed={valgt}

--- a/src/bedriftsmeny/velger/Virksomhetsvelger.css
+++ b/src/bedriftsmeny/velger/Virksomhetsvelger.css
@@ -61,7 +61,7 @@
 .navbm-virksomhetsvelger__popup {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
     padding: var(--a-spacing-3);
     background-color: var(--a-bg-subtle);
     border-radius: var(--a-border-radius-small);

--- a/src/bedriftsmeny/velger/Virksomhetsvelger.tsx
+++ b/src/bedriftsmeny/velger/Virksomhetsvelger.tsx
@@ -119,7 +119,6 @@ const Velger = ({friKomponent} : {friKomponent: boolean} ) => {
                 >
                     <div
                         className="navbm-virksomhetsvelger__popup"
-                        role="menu"
                     >
                         <div className="navbm-virksomhetsvelger__popup-header">
                             <Search
@@ -141,13 +140,12 @@ const Velger = ({friKomponent} : {friKomponent: boolean} ) => {
                             />
                             <CloseButton onClick={() => setÅpen(false)} />
                         </div>
-                        <Detail role="status" id="sokestatus">
+                        <Detail role="status">
                             {søketekst.length > 0 && (<>
                                     {antallTreff === 0 ? `Ingen treff på "${søketekst}"` : `${antallTreff} treff på "${søketekst}".`}
                             </>)}
                         </Detail>
-                        <Accordion style={{display: "flex", overflow: "auto"}}
-                                   id="virksomhetsvelger__resultatliste">
+                        <Accordion style={{display: "flex", overflow: "auto"}}>
                             <ul
                                 className="navbm-virksomhetsvelger__juridiske-enheter"
                                 onKeyDown={onKeyDown}

--- a/src/bedriftsmeny/velger/Virksomhetsvelger.tsx
+++ b/src/bedriftsmeny/velger/Virksomhetsvelger.tsx
@@ -130,7 +130,6 @@ const Velger = ({friKomponent} : {friKomponent: boolean} ) => {
                                 placeholder="Søk på virksomhet ..."
                                 label="Søk på virksomhet"
                                 autoComplete="organization"
-                                aria-owns="sokestatus virksomhetsvelger__resultatliste"
                                 onKeyDown={(e) => {
                                     if (søketekst.length > 0 && enheterflat.length > 0) {
                                         if (e.key === 'ArrowDown' || e.key === 'Down') {

--- a/src/bedriftsmeny/velger/Virksomhetsvelger.tsx
+++ b/src/bedriftsmeny/velger/Virksomhetsvelger.tsx
@@ -6,7 +6,7 @@ import {VirksomhetsvelgerContext} from './VirksomhetsvelgerProvider';
 import JuridiskEnhet from './JuridiskEnhet';
 import Dropdown from "./Dropdown";
 import FocusTrap from 'focus-trap-react';
-import {a11yOrgnr} from "@/bedriftsmeny/velger/utils";
+import {a11yOrgnr} from "./utils";
 
 const Velger = ({friKomponent} : {friKomponent: boolean} ) => {
     const buttonRef = useRef<HTMLButtonElement>(null);

--- a/src/bedriftsmeny/velger/useTastaturNavigasjon.ts
+++ b/src/bedriftsmeny/velger/useTastaturNavigasjon.ts
@@ -173,7 +173,7 @@ export const useTastaturNavigasjon = (): UseTastaturNavigasjon => {
                 toggleEkspander(fokusertEnhet);
             }
         } else {
-            const nextEnhet = organisasjonerMedState[fokusertIndex - 1];
+            const nextEnhet = organisasjonerMedState.find(({OrganizationNumber}) => OrganizationNumber === fokusertEnhet.ParentOrganizationNumber);
             if (nextEnhet !== undefined) {
                 fokuserEnhet(nextEnhet);
             }

--- a/src/bedriftsmeny/velger/useTastaturNavigasjon.ts
+++ b/src/bedriftsmeny/velger/useTastaturNavigasjon.ts
@@ -1,0 +1,196 @@
+import {JuridiskEnhetMedUnderEnheterArray, Organisasjon} from "../organisasjon";
+import {useContext, useEffect, useReducer} from "react";
+import {VirksomhetsvelgerContext} from "./VirksomhetsvelgerProvider";
+
+export type OrganisasjonMedState = Organisasjon & {
+    fokusert: boolean;
+    valgt: boolean;
+    ekspandert: boolean;
+    erHovedEnhet: boolean;
+}
+type Action = {
+    type: "FOKUSER_ENHET";
+    payload: Organisasjon;
+} | {
+    type: "FOKUSER_FØRSTE_ENHET"
+} | {
+    type: "FOKUSER_SISTE_ENHET"
+} | {
+    type: "TOGGLE_EKSPANDER_ENHET";
+    payload: Organisasjon;
+} | {
+    type: "RESET_STATE";
+    payload: { aktivtOrganisasjonstre: JuridiskEnhetMedUnderEnheterArray[], valgtOrganisasjon: string };
+}
+const reducer = (state: OrganisasjonMedState[], action: Action): OrganisasjonMedState[] => {
+    switch (action.type) {
+        case "FOKUSER_ENHET":
+            return state.map((org) => ({
+                ...org,
+                fokusert: org.OrganizationNumber === action.payload.OrganizationNumber,
+            }));
+
+        case "FOKUSER_FØRSTE_ENHET":
+            return state.map((org, i) => ({
+                ...org,
+                fokusert: i === 0,
+            }));
+
+        case "FOKUSER_SISTE_ENHET":
+            const lastIndex = state.findLastIndex((org) => org.erHovedEnhet || org.ekspandert);
+            return state.map((org, i) => ({
+                ...org,
+                fokusert: i === lastIndex,
+            }));
+
+        case "TOGGLE_EKSPANDER_ENHET":
+            return state.map((org) => ({
+                ...org,
+                ekspandert: (
+                    org.OrganizationNumber === action.payload.OrganizationNumber
+                    || org.ParentOrganizationNumber === action.payload.OrganizationNumber
+                ) ? !org.ekspandert : org.ekspandert,
+            }));
+
+        case "RESET_STATE":
+            return initState(action.payload);
+    }
+}
+
+const initState = (
+    {
+        aktivtOrganisasjonstre,
+        valgtOrganisasjon
+    }: {
+        aktivtOrganisasjonstre: JuridiskEnhetMedUnderEnheterArray[],
+        valgtOrganisasjon: string
+    }
+): OrganisasjonMedState[] => {
+    const valgtOrganisasjonErITre = aktivtOrganisasjonstre.some(({Underenheter}) => Underenheter.some(({OrganizationNumber}) => OrganizationNumber === valgtOrganisasjon));
+    return aktivtOrganisasjonstre
+        .flatMap(({JuridiskEnhet, Underenheter}, level) => [
+            {
+                ...JuridiskEnhet,
+                ekspandert: Underenheter.some(({OrganizationNumber}) => OrganizationNumber === valgtOrganisasjon),
+                erHovedEnhet: true,
+                valgt: false,
+                fokusert: false,
+            }, ...Underenheter.map((Underenhet, i) => ({
+                ...Underenhet,
+                erHovedEnhet: false,
+                fokusert: valgtOrganisasjonErITre ? Underenhet.OrganizationNumber === valgtOrganisasjon : level === 0 && i === 0,
+                valgt: valgtOrganisasjonErITre ? Underenhet.OrganizationNumber === valgtOrganisasjon : level === 0 && i === 0,
+                ekspandert: Underenheter.some(({OrganizationNumber}) => OrganizationNumber === valgtOrganisasjon)
+            }))
+        ]);
+}
+
+
+export type UseTastaturNavigasjon = {
+    fokusertEnhet: OrganisasjonMedState,
+    organisasjonerMedState: OrganisasjonMedState[],
+    fokuserFørsteEnhet: () => void,
+    fokuserSisteEnhet: () => void,
+    pilOpp: () => void,
+    pilNed: () => void,
+    pilHøyre: () => void,
+    pilVenstre: () => void,
+    toggleEkspander: (enhet: Organisasjon) => void,
+    fokuserEnhet: (enhet: Organisasjon) => void,
+    resetState: () => void,
+};
+export const useTastaturNavigasjon = (): UseTastaturNavigasjon => {
+    const {
+        valgtOrganisasjon,
+        aktivtOrganisasjonstre,
+    } = useContext(VirksomhetsvelgerContext);
+    const [organisasjonerMedState, dispatch] = useReducer(
+        reducer,
+        {aktivtOrganisasjonstre, valgtOrganisasjon: valgtOrganisasjon.OrganizationNumber},
+        initState,
+    );
+
+    const resetState = () => {
+        dispatch({
+            type: "RESET_STATE",
+            payload: {aktivtOrganisasjonstre, valgtOrganisasjon: valgtOrganisasjon.OrganizationNumber},
+        })
+    };
+
+    useEffect(() => {
+        // Reset state when the active tree changes
+        resetState()
+    }, [JSON.stringify(aktivtOrganisasjonstre), valgtOrganisasjon.OrganizationNumber]);
+    const fokusertEnhet = organisasjonerMedState.find(({fokusert}) => fokusert) ?? (organisasjonerMedState.find(({valgt}) => valgt) ?? organisasjonerMedState[0] ?? valgtOrganisasjon);
+    const fokusertIndex = organisasjonerMedState.findIndex(({OrganizationNumber}) => OrganizationNumber === fokusertEnhet.OrganizationNumber);
+
+    const fokuserFørsteEnhet = () => {
+        dispatch({type: 'FOKUSER_FØRSTE_ENHET'});
+    };
+
+    const fokuserSisteEnhet = () => {
+        dispatch({type: 'FOKUSER_SISTE_ENHET'});
+    };
+
+    const pilOpp = () => {
+        const nextEnhet = organisasjonerMedState.slice(0, fokusertIndex).findLast((org) => org.erHovedEnhet || org.ekspandert)
+        if (nextEnhet !== undefined) {
+            dispatch({type: "FOKUSER_ENHET", payload: nextEnhet})
+        }
+    };
+
+    const pilNed = () => {
+        const nextEnhet = organisasjonerMedState.slice(fokusertIndex + 1).find((org) => org.erHovedEnhet || org.ekspandert)
+        if (nextEnhet !== undefined) {
+            dispatch({type: "FOKUSER_ENHET", payload: nextEnhet})
+        }
+    };
+
+    const pilHøyre = () => {
+        if (fokusertEnhet.erHovedEnhet) {
+            if (fokusertEnhet.ekspandert) {
+                const nextEnhet = organisasjonerMedState[fokusertIndex + 1];
+                if (nextEnhet !== undefined) {
+                    dispatch({type: "FOKUSER_ENHET", payload: nextEnhet})
+                }
+            } else {
+                dispatch({type: 'TOGGLE_EKSPANDER_ENHET', payload: fokusertEnhet})
+            }
+        }
+    };
+
+    const toggleEkspander = (enhet: Organisasjon) => {
+        dispatch({type: 'TOGGLE_EKSPANDER_ENHET', payload: enhet})
+    };
+
+    const fokuserEnhet = (enhet: Organisasjon) => {
+        dispatch({type: "FOKUSER_ENHET", payload: enhet})
+    };
+
+    const pilVenstre = () => {
+        if (fokusertEnhet.erHovedEnhet) {
+            if (fokusertEnhet.ekspandert) {
+                toggleEkspander(fokusertEnhet);
+            }
+        } else {
+            const nextEnhet = organisasjonerMedState[fokusertIndex - 1];
+            if (nextEnhet !== undefined) {
+                fokuserEnhet(nextEnhet);
+            }
+        }
+    };
+
+    return {
+        fokusertEnhet,
+        organisasjonerMedState,
+        fokuserFørsteEnhet,
+        fokuserSisteEnhet,
+        pilOpp,
+        pilNed,
+        pilHøyre,
+        pilVenstre,
+        toggleEkspander,
+        fokuserEnhet,
+        resetState,
+    }
+}

--- a/src/bedriftsmeny/velger/utils.ts
+++ b/src/bedriftsmeny/velger/utils.ts
@@ -44,3 +44,5 @@ export const useOrgnrSearchParam: OrgnrSearchParamType = () => {
 
     return [currentOrgnr, setOrgnr];
 };
+
+export const a11yOrgnr = (str: string) => str.replaceAll(/(\d)/g, "$1 ")


### PR DESCRIPTION
Ved brukertest kom det opp noen mangler for brukere av skjermleser.
Denne PRen er et forsøk på å forbedre de manglene som ble avdekket av brukertesten.

Følgende endringer er gjort:
* Bedre beskrivelse av hva som er valgt og hva brukeren kan gjøre i komponenten.
* Endre tabbing slik at bruker ikke blir fanget i listen og må tabbe gjennom en lang liste av bedrifter. Tab flytter nå fokus fra listen til søkefelt til lukk knapp, ikke mellom hvert element i listen. 
* Navigering i listen gjøres med piltaster iht retningslinjer for navigering i tre. På denne måten er det lett å forstå for brukere med skjermleser.
* Mer lesbart org og virksomhetnummer for skjermlesere
* Gjør søk mer forståelig for brukere med skjermleser
* fjerner role=menu og menuitemradio. Dette skaper utfordringer for søkefeltet. Skjermlesere behandler da søkefeltet annerledes, og det blir vanskelig å bruke.
* knapper får type=button slik at bedriftsmenyen fungerer i en form. Det fikses også slik at knappene reflekterer tilstand på menyen slik at det er forståelig for en bruker med skjermleser
* det skilles på fokusert og valgt enhet. fokusert enhet endres ved navigering. Valgt enhet settes kun når man faktisk velger. 